### PR TITLE
Use latest version of lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = {
       cosmic.objects.all = objects;
       cosmic.objects.type = _.groupBy(objects, 'type_slug');
       cosmic.object = _.map(objects, keyMetafields);
-      cosmic.object = _.indexBy(cosmic.object, 'slug');
+      cosmic.object = _.keyBy(cosmic.object, 'slug');
       return callback(false, cosmic);
     });
   },
@@ -70,7 +70,7 @@ module.exports = {
       cosmic.objects = {};
       cosmic.objects.all = objects;
       cosmic.object = _.map(objects, keyMetafields);
-      cosmic.object = _.indexBy(cosmic.object, "slug");
+      cosmic.object = _.keyBy(cosmic.object, "slug");
       return callback(false, cosmic);
     });
   },
@@ -96,7 +96,7 @@ module.exports = {
       var object = response.object;
       var metafields = object.metafields;
       if(metafields){
-        object.metafield = _.indexBy(metafields, "key");
+        object.metafield = _.keyBy(metafields, "key");
       }
       cosmic.object = object;
       return callback(false, cosmic);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "es6-promise": "^3.0.2",
     "isomorphic-fetch": "^2.2.0",
-    "lodash": "^3.10.1"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Hi there,

This pull request upgrade `lodash` to its latest version.

With the verison 4, `_.indexBy` has been renamed to `_.keyBy`.

Keep up the good work with CosmicJS :)