### PR TITLE
Added total property in getObjectType response

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ module.exports = {
       cosmic.objects.all = objects;
       cosmic.object = _.map(objects, keyMetafields);
       cosmic.object = _.keyBy(cosmic.object, "slug");
+      cosmic.total = response.total;
       return callback(false, cosmic);
     });
   },


### PR DESCRIPTION
The response for getObjectType will now include a total property. This property indicates the total number of objects under an object type 