### PR TITLE
Prevent error on client side if 'process.env' is not set

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -1,6 +1,6 @@
-const API_URL = process?.env?.COSMIC_API_URL ?? 'https://api.cosmicjs.com'
-const UPLOAD_API_URL = process?.env?.UPLOAD_API_URL ?? 'https://upload.cosmicjs.com'
-const API_VERSION = process?.env?.COSMIC_API_VERSION ?? 'v2'
+const API_URL = process?.env?.COSMIC_API_URL || 'https://api.cosmicjs.com'
+const UPLOAD_API_URL = process?.env?.UPLOAD_API_URL || 'https://upload.cosmicjs.com'
+const API_VERSION = process?.env?.COSMIC_API_VERSION || 'v2'
 const URI = `${API_URL}/${API_VERSION}`
 
 module.exports = {

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -1,6 +1,6 @@
-const API_URL = process.env.COSMIC_API_URL || 'https://api.cosmicjs.com'
-const UPLOAD_API_URL = process.env.UPLOAD_API_URL || 'https://upload.cosmicjs.com'
-const API_VERSION = process.env.COSMIC_API_VERSION || 'v2'
+const API_URL = process?.env?.COSMIC_API_URL ?? 'https://api.cosmicjs.com'
+const UPLOAD_API_URL = process?.env?.UPLOAD_API_URL ?? 'https://upload.cosmicjs.com'
+const API_VERSION = process?.env?.COSMIC_API_VERSION ?? 'v2'
 const URI = `${API_URL}/${API_VERSION}`
 
 module.exports = {


### PR DESCRIPTION
Hello,

I propose this fix because I have been myself a victim of this.

Your library is to be used on both server and client side. But client side `process` and `process.env` are not supposed to be set.

I saw in the documentation that you go to great length to help people configure their environment so `process.env` is set (by using `create-react-app` which sets it for example).

But why not just change the code so that if we're client side and `process` or `process.env` are not set, the library does not fail miserably?

Of course here I'm using the optional chaining and null coalescing operators. But if your build tools does not allow them, there are other (old school, more verbose) ways to write it.

Regards.